### PR TITLE
Initial implementation of share buttons

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -21,6 +21,7 @@
 
         ga('create', '#{ENV['GOOGLE_ANALYTICS_ID']}', '#{ENV['GOOGLE_ANALYTICS_DOMAIN']}');
         ga('send', 'pageview');
+    = stylesheet_link_tag "//maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css"
     = stylesheet_link_tag "application"
   %body
     = yield

--- a/app/views/users/thank_you.html.haml
+++ b/app/views/users/thank_you.html.haml
@@ -1,3 +1,9 @@
 %h2
-  = t("titles.thank_you", :thing => t("defaults.thing"))
+  = t("titles.thank_you", thing: t("defaults.thing"))
+  %a{ href: "mailto:?subject=#{URI.encode(t("titles.main", thing: t("defaults.thing")))}&body=#{URI.encode(t("titles.share_text", thing: t("defaults.thing")))}%20#{root_url}" }
+    %i.fa.fa-envelope-square.fa-2x
+  %a{ href: "https://www.facebook.com/sharer/sharer.php?u=#{root_url}" }
+    %i.fa.fa-facebook-square.fa-2x
+  %a{ href: "https://twitter.com/intent/tweet?text=#{URI.encode(t("titles.share_text", thing: t("defaults.thing")))}"}
+    %i.fa.fa-twitter-square.fa-2x
 = render :partial => 'things/abandon'

--- a/app/views/users/thank_you.html.haml
+++ b/app/views/users/thank_you.html.haml
@@ -1,9 +1,9 @@
 %h2
   = t("titles.thank_you", thing: t("defaults.thing"))
-  %a{ href: "mailto:?subject=#{URI.encode(t("titles.main", thing: t("defaults.thing")))}&body=#{URI.encode(t("titles.share_text", thing: t("defaults.thing")))}%20#{root_url}" }
+  %a{ href: "mailto:?subject=#{URI.encode(t("titles.main", thing: t("defaults.thing")))}&body=#{URI.encode(t("titles.email_text", root_url: root_url, thing: t("defaults.thing")))}" }
     %i.fa.fa-envelope-square.fa-2x
   %a{ href: "https://www.facebook.com/sharer/sharer.php?u=#{root_url}" }
     %i.fa.fa-facebook-square.fa-2x
-  %a{ href: "https://twitter.com/intent/tweet?text=#{URI.encode(t("titles.share_text", thing: t("defaults.thing")))}"}
+  %a{ href: "https://twitter.com/intent/tweet?text=#{URI.encode(t("titles.tweet_text", root_url: root_url, thing: t("defaults.thing")))}"}
     %i.fa.fa-twitter-square.fa-2x
 = render :partial => 'things/abandon'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -81,7 +81,8 @@ en:
     ofline: "of %{organization}"
     sign_in: "Sign in to adopt this %{thing}"
     thank_you: "Thank you for adopting this %{thing}!"
-    share_text: "I just adopted a %{thing}!"
+    email_text: "Flooded streets aren’t fun. I adopted my own storm drain at %{root_url}. Claim and name yours!"
+    tweet_text: "Flooded streets aren’t fun. I adopted my own storm drain at %{root_url}. Claim and name yours #ElNino #sfsewer"
     tos: "Terms of Service"
   sponsors:
     built: "Code for San Francisco"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -81,6 +81,7 @@ en:
     ofline: "of %{organization}"
     sign_in: "Sign in to adopt this %{thing}"
     thank_you: "Thank you for adopting this %{thing}!"
+    share_text: "I just adopted a %{thing}!"
     tos: "Terms of Service"
   sponsors:
     built: "Code for San Francisco"


### PR DESCRIPTION
Opening this to get initial feedback on #11

So far it looks something like: 
![2015-11-05-222633_313x213_scrot](https://cloud.githubusercontent.com/assets/316880/10990848/5aaed8e2-840c-11e5-846d-cc48f0444be6.png)

@hackajesse I'll still need some copy (currently it just defaults to `I just adopted a drain!` for the body of the e-mail and tweet. Facebook only allows you to prepopulate the URL. Were there any other services you think would be good to include?