### PR TITLE
Fix mobile issues related to form inputs

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -24,6 +24,11 @@ img[title="Code for San Francisco"]{
   width:100%;
 }
 
+input[type="text"], input[type="email"], input[type="password"], input[type="search"]
+{
+    font-size:16px;
+}
+
 .navbar {
   margin-bottom: 0;
 }

--- a/app/views/sidebar/_search.html.haml
+++ b/app/views/sidebar/_search.html.haml
@@ -12,7 +12,3 @@
       = t("buttons.edit_profile")
     %a{:href => destroy_user_session_path, :id => "sign_out_link", :class => "btn btn-danger btn-block"}
       = t("buttons.sign_out")
-:javascript
-  $(function() {
-    $('#address').focus();
-  });


### PR DESCRIPTION
#19 and #59 should be addressed here. I was able to test on an actual phone (but not all phones) and so far it's working. When focus turns to an input, it no longer auto zooms. Also, the autofocus has been dropped for search to avoid the keyboard coming up when you first drop into the mobile site.

Can anyone on @sfbrigade/core-website-tools take a look and see if this appears ready for merge?