### PR TITLE
Deploy to Heroku from TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,16 +3,16 @@ bundler_args: "--without assets:development:production"
 cache: bundler
 language: ruby
 rvm:
-  - 2.2.3
+- 2.2.3
 script:
-  - bundle exec rake
-  - bundle exec rubocop
+- bundle exec rake
+- bundle exec rubocop
 sudo: false
 deploy:
-  api_key:
-    secure: Ck6BzHMtPmYsBY/PbVnfIE6wnSe9s6fYDkvzYZtT/2qud4j4ElhV9el0ZbDhiTmix0PMwcCnN/Tpw5GbLVaHncDaJkvb6ucEBNyC7xECjNAFsxE6lu3yKATsY2hta7OQ8NwLlvAZpzCLMZQf9lzoSNbh2h/p+CwSNR7vOkw0FNc=
-  app: adopt-a-drain
-  on:
-    repo: codeforamerica/adopt-a-drain
   provider: heroku
-  strategy: git
+  api_key:
+    secure: gzI1Bfic6d7vKRoNY4UkHdsJyLYc+0E6E4rs+PLHF1z3/Eg9KS8A76YfQDc4nrocr062yT7u2bb2c/4bX1C693N9wSnCCU5gmpLIOo3xdLDFmAWxhEsDM05BYsBFUSdKUpyH9ZxJVXEcgSbPVeYmpHUol48NtmSCVUiLufLF0smLkXghSb9awbdk9rfOTdscypOJsDTYS6LoKft+i6TrddkGt7rVH5A+2gC8LqRUet88Ka/9ak8nP1dNvajvjcNYcAnHBBOyXxQaSudJelZHd+gVpAQkEnWcf9q1S+koG/0Sa1wUkgnp0RLYyALFWo1Q3o3aUA0bEWgAzoc9MKFaHcioopP9zJ/uhb+mc48sS8iIy7gd+sadGbRQKaWx45si7HE/MCY1K9hRmEXMehKRGzf9jpCH5iDc3wO5eXNPTlcK/nO6Q7b9hFp0gOg3J7sRMKFmjZgGL+IKJjBa6yFI0VGXme2sG6h5/gWBERP1xtNF8wVilhlAbwwAChAXB+aye0FnLRC89eXv5lfawCqsWM+YJzed2a1X0myCCSAgej2HJFTDIcKTOa33uIwQyNS+MqBHfxSLDWB4tPe3bx+4qz30zG/7++MbDWveIsYcybfY/nmkLvp/TM8XVQtVAcgBrez0aPN//Hg2IEqEaTRIcsBD+hlT1r4gvFJ0lTQW51I=
+  app: adoptadrainsf
+  on:
+    repo: sfbrigade/adopt-a-drain
+    branch: production

--- a/test/controllers/main_controller_test.rb
+++ b/test/controllers/main_controller_test.rb
@@ -12,7 +12,7 @@ class MainControllerTest < ActionController::TestCase
     get :index
     assert_response :success
     assert_select 'title', 'Adopt-a-Drain'
-    assert_select 'p#tagline', 'Claim responsibility for shoveling out a fire drain after it snows.'
+    assert_select 'p#tagline', 'Claim responsibility for maintaining a local storm drain.'
   end
 
   test 'should show search form when signed in' do
@@ -25,7 +25,7 @@ class MainControllerTest < ActionController::TestCase
     end
     assert_select 'label#city_state_label', 'City'
     assert_select 'select#city_state' do
-      assert_select 'option', 'Boston, Massachusetts'
+      assert_select 'option', 'San Francisco, California'
     end
     assert_select 'label#address_label', 'Address, Neighborhood'
     assert_select 'input#address', true


### PR DESCRIPTION
Allows us to only deploy code where the tests are passing. I personally think
this is better, but am curious if there are any other opinions.

We could remove the direct Github -> Heroku integration after this is merged.