### PR TITLE
Fix displaying of form errors

### DIFF
--- a/app/assets/javascripts/main.js.erb
+++ b/app/assets/javascripts/main.js.erb
@@ -2,6 +2,7 @@ $(function() {
   var initialLocation;
   var center = new google.maps.LatLng(37.774929, -122.419416);
   var browserSupportFlag =  new Boolean();
+  var errorClass = 'has-error';
   var mapOptions = {
     center: center,
     disableDoubleClickZoom: false,
@@ -125,10 +126,10 @@ $(function() {
       success: function(data) {
         $(submitButton).attr("disabled", false);
         if(data.errors) {
-          $('#address').parent().addClass('error');
+          $('#address').parent().addClass(errorClass);
           $('#address').focus();
         } else {
-          $('#address').parent().removeClass('error');
+          $('#address').parent().removeClass(errorClass);
           var i = -1;
           $(data).each(function(index, thing) {
             if($.inArray(thing.id, thingIds) === -1) {
@@ -160,7 +161,7 @@ $(function() {
     $(submitButton).attr("disabled", true);
     if($('#address').val() === '') {
       $(submitButton).attr("disabled", false);
-      $('#address').parent().addClass('error');
+      $('#address').parent().addClass(errorClass);
       $('#address').focus();
     } else {
       $.ajax({
@@ -173,16 +174,16 @@ $(function() {
         },
         error: function(jqXHR) {
           $(submitButton).attr("disabled", false);
-          $('#address').parent().addClass('error');
+          $('#address').parent().addClass(errorClass);
           $('#address').focus();
         },
         success: function(data) {
           $(submitButton).attr("disabled", false);
           if(data.errors) {
-            $('#address').parent().addClass('error');
+            $('#address').parent().addClass(errorClass);
             $('#address').focus();
           } else {
-            $('#address').parent().removeClass('error');
+            $('#address').parent().removeClass(errorClass);
             addMarkersAround(data[0], data[1]);
             var center = new google.maps.LatLng(data[0], data[1]);
             map.setCenter(center);
@@ -240,22 +241,22 @@ $(function() {
     var errors = []
     if(!/[\w\.%\+]+@[\w]+\.+[\w]{2,}/.test($('#user_email').val())) {
       errors.push($('#user_email'));
-      $('#user_email').parent().addClass('error');
+      $('#user_email').parent().addClass(errorClass);
     } else {
-      $('#user_email').parent().removeClass('error');
+      $('#user_email').parent().removeClass(errorClass);
     }
     if(!$(this).data('state') || $(this).data('state') === 'user_sign_up') {
       if($('#user_name').val() === '') {
         errors.push($('#user_name'));
-        $('#user_name').parent().addClass('error');
+        $('#user_name').parent().addClass(errorClass);
       } else {
-        $('#user_name').parent().removeClass('error');
+        $('#user_name').parent().removeClass(errorClass);
       }
       if($('#user_password_confirmation').val().length < 6 || $('#user_password_confirmation').val().length > 20) {
         errors.push($('#user_password_confirmation'));
-        $('#user_password_confirmation').parent().addClass('error');
+        $('#user_password_confirmation').parent().addClass(errorClass);
       } else {
-        $('#user_password_confirmation').parent().removeClass('error');
+        $('#user_password_confirmation').parent().removeClass(errorClass);
       }
       if(errors.length > 0) {
         $(submitButton).attr("disabled", false);
@@ -282,27 +283,27 @@ $(function() {
             $(submitButton).attr("disabled", false);
             if(data.errors.email) {
               errors.push($('#user_email'));
-              $('#user_email').parent().addClass('error');
+              $('#user_email').parent().addClass(errorClass);
             }
             if(data.errors.name) {
               errors.push($('#user_name'));
-              $('#user_name').parent().addClass('error');
+              $('#user_name').parent().addClass(errorClass);
             }
             if(data.errors.organization) {
               errors.push($('#user_organization'));
-              $('#user_organization').parent().addClass('error');
+              $('#user_organization').parent().addClass(errorClass);
             }
             if(data.errors.voice_number) {
               errors.push($('#user_voice_number'));
-              $('#user_voice_number').parent().addClass('error');
+              $('#user_voice_number').parent().addClass(errorClass);
             }
             if(data.errors.sms_number) {
               errors.push($('#user_sms_number'));
-              $('#user_sms_number').parent().addClass('error');
+              $('#user_sms_number').parent().addClass(errorClass);
             }
             if(data.errors.password) {
               errors.push($('#user_password_confirmation'));
-              $('#user_password_confirmation').parent().addClass('error');
+              $('#user_password_confirmation').parent().addClass(errorClass);
             }
             errors[0].focus();
           },
@@ -328,9 +329,9 @@ $(function() {
     } else if($(this).data('state') === 'user_sign_in') {
       if($('#user_password').val().length < 6 || $('#user_password').val().length > 20) {
         errors.push($('#user_password'));
-        $('#user_password').parent().addClass('error');
+        $('#user_password').parent().addClass(errorClass);
       } else {
-        $('#user_password').parent().removeClass('error');
+        $('#user_password').parent().removeClass(errorClass);
       }
       if(errors.length > 0) {
         $(submitButton).attr("disabled", false);
@@ -350,7 +351,7 @@ $(function() {
           },
           error: function(jqXHR) {
             $(submitButton).attr("disabled", false);
-            $('#user_password').parent().addClass('error');
+            $('#user_password').parent().addClass(errorClass);
             $('#user_password').focus();
           },
           success: function(data) {
@@ -388,7 +389,7 @@ $(function() {
           },
           error: function(jqXHR) {
             $(submitButton).attr("disabled", false);
-            $('#user_email').parent().addClass('error');
+            $('#user_email').parent().addClass(errorClass);
             $('#user_email').focus();
           },
           success: function() {
@@ -507,33 +508,33 @@ $(function() {
     var errors = []
     if(!/[\w\.%\+\]+@[\w\]+\.+[\w]{2,}/.test($('#user_email').val())) {
       errors.push($('#user_email'));
-      $('#user_email').parent().addClass('error');
+      $('#user_email').parent().addClass(errorClass);
     } else {
-      $('#user_email').parent().removeClass('error');
+      $('#user_email').parent().removeClass(errorClass);
     }
     if($('#user_name').val() === '') {
       errors.push($('#user_name'));
-      $('#user_name').parent().addClass('error');
+      $('#user_name').parent().addClass(errorClass);
     } else {
-      $('#user_name').parent().removeClass('error');
+      $('#user_name').parent().removeClass(errorClass);
     }
     if($('#user_zip').val() != '' && !/^\d{5}(-\d{4})?$/.test($('#user_zip').val())) {
       errors.push($('#user_zip'));
-      $('#user_zip').parent().addClass('error');
+      $('#user_zip').parent().addClass(errorClass);
     } else {
-      $('#user_zip').parent().removeClass('error');
+      $('#user_zip').parent().removeClass(errorClass);
     }
     if($('#user_password').val() && ($('#user_password').val().length < 6 || $('#user_password').val().length > 20)) {
       errors.push($('#user_password'));
-      $('#user_password').parent().addClass('error');
+      $('#user_password').parent().addClass(errorClass);
     } else {
-      $('#user_password').parent().removeClass('error');
+      $('#user_password').parent().removeClass(errorClass);
     }
     if($('#user_current_password').val().length < 6 || $('#user_current_password').val().length > 20) {
       errors.push($('#user_current_password'));
-      $('#user_current_password').parent().addClass('error');
+      $('#user_current_password').parent().addClass(errorClass);
     } else {
-      $('#user_current_password').parent().removeClass('error');
+      $('#user_current_password').parent().removeClass(errorClass);
     }
     if(errors.length > 0) {
       $(submitButton).attr("disabled", false);
@@ -569,51 +570,51 @@ $(function() {
           $(submitButton).attr("disabled", false);
           if(data.errors.email) {
             errors.push($('#user_email'));
-            $('#user_email').parent().addClass('error');
+            $('#user_email').parent().addClass(errorClass);
           }
           if(data.errors.name) {
             errors.push($('#user_name'));
-            $('#user_name').parent().addClass('error');
+            $('#user_name').parent().addClass(errorClass);
           }
           if(data.errors.organization) {
             errors.push($('#user_organization'));
-            $('#user_organization').parent().addClass('error');
+            $('#user_organization').parent().addClass(errorClass);
           }
           if(data.errors.voice_number) {
             errors.push($('#user_voice_number'));
-            $('#user_voice_number').parent().addClass('error');
+            $('#user_voice_number').parent().addClass(errorClass);
           }
           if(data.errors.sms_number) {
             errors.push($('#user_sms_number'));
-            $('#user_sms_number').parent().addClass('error');
+            $('#user_sms_number').parent().addClass(errorClass);
           }
           if(data.errors.address_1) {
             errors.push($('#user_address_1'));
-            $('#user_address_1').parent().addClass('error');
+            $('#user_address_1').parent().addClass(errorClass);
           }
           if(data.errors.address_2) {
             errors.push($('#user_address_2'));
-            $('#user_address_2').parent().addClass('error');
+            $('#user_address_2').parent().addClass(errorClass);
           }
           if(data.errors.city) {
             errors.push($('#user_city'));
-            $('#user_city').parent().addClass('error');
+            $('#user_city').parent().addClass(errorClass);
           }
           if(data.errors.state) {
             errors.push($('#user_state'));
-            $('#user_state').parent().addClass('error');
+            $('#user_state').parent().addClass(errorClass);
           }
           if(data.errors.zip) {
             errors.push($('#user_zip'));
-            $('#user_zip').parent().addClass('error');
+            $('#user_zip').parent().addClass(errorClass);
           }
           if(data.errors.password) {
             errors.push($('#user_password'));
-            $('#user_password').parent().addClass('error');
+            $('#user_password').parent().addClass(errorClass);
           }
           if(data.errors.current_password) {
             errors.push($('#user_current_password'));
-            $('#user_current_password').parent().addClass('error');
+            $('#user_current_password').parent().addClass(errorClass);
           }
           errors[0].focus();
         },

--- a/app/views/passwords/edit.html.haml
+++ b/app/views/passwords/edit.html.haml
@@ -3,7 +3,7 @@
 = form_for resource, :as => resource_name, :url => password_path(resource_name), :html => {:id => "edit_form", :method => :put} do |f|
   = f.hidden_field "reset_password_token"
   %fieldset.control-group
-    = f.label "password", t("labels.password_new"), :id => "user_password_label"
+    = f.label "password", t("labels.password_new"), :id => "user_password_label", :class => "control-label"
     = f.password_field "password"
   %fieldset.form-actions
     = f.submit t("buttons.change_password"), :class => "btn"

--- a/app/views/sidebar/_combo_form.html.haml
+++ b/app/views/sidebar/_combo_form.html.haml
@@ -1,7 +1,7 @@
 = form_for :user, :html => {:id => "combo-form", :class => "form-vertical"} do |f|
   %fieldset#common_fields
     .form-group
-      %label{:for => "user_email", :id => "user_email_label"}
+      %label{:for => "user_email", :id => "user_email_label", :class => 'control-label'}
         = t("labels.email")
         %small
           = image_tag "lock.png", :class => "lock", :alt => t("captions.private"), :title => t("captions.private")
@@ -12,31 +12,31 @@
       = f.label "existing", radio_button_tag("user", "existing").html_safe + t("labels.user_existing")
   %fieldset#user_sign_up_fields
     .form-group
-      %label{:for => "user_name", :id => "user_name_label"}
+      %label{:for => "user_name", :id => "user_name_label", :class => 'control-label'}
         = t("labels.name")
         %small
           = t("captions.public")
       = f.text_field "name", :class => "form-control"
     .form-group
-      %label{:for => "user_organization", :id => "user_organization_label"}
+      %label{:for => "user_organization", :id => "user_organization_label", :class => 'control-label'}
         = t("labels.organization")
         %small
           = t("captions.public")
       = f.text_field "organization", :class => "form-control"
     .form-group
-      %label{:for => "user_voice_number", :id => "user_voice_number_label"}
+      %label{:for => "user_voice_number", :id => "user_voice_number_label", :class => 'control-label'}
         = t("labels.voice_number")
         %small
           = image_tag "lock.png", :class => "lock", :alt => t("captions.private"), :title => t("captions.private")
       = f.telephone_field "voice_number", :placeholder => t("defaults.voice_number"), :class => "form-control"
     .form-group
-      %label{:for => "user_sms_number", :id => "user_sms_number_label"}
+      %label{:for => "user_sms_number", :id => "user_sms_number_label", :class => 'control-label'}
         = t("labels.sms_number")
         %small
           = image_tag "lock.png", :class => "lock", :alt => t("captions.private"), :title => t("captions.private")
       = f.telephone_field "sms_number", :placeholder => t("defaults.sms_number"), :class => "form-control"
     .form-group
-      %label{:for => "user_password_confirmation", :id => "user_password_confirmation_label"}
+      %label{:for => "user_password_confirmation", :id => "user_password_confirmation_label", :class => 'control-label'}
         = t("labels.password_choose")
         %small
           = image_tag "lock.png", :class => "lock", :alt => t("captions.private"), :title => t("captions.private")
@@ -47,7 +47,7 @@
       = f.submit t("buttons.sign_up"), :class => "btn btn-primary btn-block"
   %fieldset#user_sign_in_fields{:style => "display: none;"}
     .form-group
-      %label{:for => "user_password", :id => "user_password_label"}
+      %label{:for => "user_password", :id => "user_password_label", :class => 'control-label'}
         = t("labels.password")
         %small
           = image_tag "lock.png", :class => "lock", :alt => t("captions.private"), :title => t("captions.private")

--- a/app/views/sidebar/_search.html.haml
+++ b/app/views/sidebar/_search.html.haml
@@ -1,10 +1,10 @@
 = form_tag "/address", :method => "get", :id => "address_form", :class => "search-form" do
   = hidden_field_tag "limit", params[:limit] || 10
   %fieldset.form-group.hidden
-    = label_tag "city_state", t("labels.city_state"), :id => "city_state_label"
+    = label_tag "city_state", t("labels.city_state"), :id => "city_state_label", :class => "control-label"
     = select_tag "city_state", "<option value=\"#{t("defaults.city_state")}\" selected=\"selected\">#{t("defaults.city_state")}</option>".html_safe, :class => "form-control"
   %fieldset.form-group
-    = label_tag "address", t("labels.address"), :id => "address_label"
+    = label_tag "address", t("labels.address"), :id => "address_label", :class => "control-label"
     = search_field_tag "address", params[:address], :placeholder => [t("defaults.address_1"), t("defaults.neighborhood")].join(", "), :class => "search-query form-control"
   %fieldset.form-actions
     = submit_tag t("buttons.find", :thing => t("defaults.thing").pluralize), :class => "btn btn-primary btn-block"

--- a/app/views/sidebar/edit_profile.html.haml
+++ b/app/views/sidebar/edit_profile.html.haml
@@ -1,73 +1,73 @@
 = form_for resource, :as => resource_name, :url => registration_path(resource_name), :html => {:id => "edit_form", :method => :put} do |f|
   = f.hidden_field "id"
   %fieldset.form-group
-    %label{:for => "user_email", :id => "user_email_label"}
+    %label{:for => "user_email", :id => "user_email_label", :class => 'control-label'}
       = t("labels.email")
       %small
         = image_tag "lock.png", :class => "lock", :alt => t("captions.private"), :title => t("captions.private")
     = f.email_field "email", :class => "form-control"
   %fieldset.form-group
-    %label{:for => "user_name", :id => "user_name_label"}
+    %label{:for => "user_name", :id => "user_name_label", :class => 'control-label'}
       = t("labels.name")
       %small
         = t("captions.public")
     = f.text_field "name", :class => "form-control"
   %fieldset.form-group
-    %label{:for => "user_organization", :id => "user_organization_label"}
+    %label{:for => "user_organization", :id => "user_organization_label", :class => 'control-label'}
       = t("labels.organization")
       %small
         = t("captions.public")
     = f.text_field "organization", :class => "form-control"
   %fieldset.form-group
-    %label{:for => "user_voice_number", :id => "user_voice_number_label"}
+    %label{:for => "user_voice_number", :id => "user_voice_number_label", :class => 'control-label'}
       = t("labels.voice_number")
       %small
         = image_tag "lock.png", :class => "lock", :alt => t("captions.private"), :title => t("captions.private")
     = f.telephone_field "voice_number", :placeholder => t("defaults.voice_number"), :value => number_to_phone(f.object.voice_number), :class => "form-control"
   %fieldset.form-group
-    %label{:for => "user_sms_number", :id => "user_sms_number_label"}
+    %label{:for => "user_sms_number", :id => "user_sms_number_label", :class => 'control-label'}
       = t("labels.sms_number")
       %small
         = image_tag "lock.png", :class => "lock", :alt => t("captions.private"), :title => t("captions.private")
     = f.telephone_field "sms_number", :placeholder => t("defaults.sms_number"), :value => number_to_phone(f.object.sms_number), :class => "form-control"
   %fieldset.form-group
-    %label{:for => "user_address_1", :id => "user_address_1_label"}
+    %label{:for => "user_address_1", :id => "user_address_1_label", :class => 'control-label'}
       = t("labels.address_1")
       %small
         = image_tag "lock.png", :class => "lock", :alt => t("captions.private"), :title => t("captions.private")
     = f.text_field "address_1", :placeholder => t("defaults.address_1"), :class => "form-control"
   %fieldset.form-group
-    %label{:for => "user_address_2", :id => "user_address_2_label"}
+    %label{:for => "user_address_2", :id => "user_address_2_label", :class => 'control-label'}
       = t("labels.address_2")
       %small
         = image_tag "lock.png", :class => "lock", :alt => t("captions.private"), :title => t("captions.private")
     = f.text_field "address_2", :placeholder => t("defaults.address_2"), :class => "form-control"
   %fieldset.form-group
-    %label{:for => "user_city", :id => "user_city_label"}
+    %label{:for => "user_city", :id => "user_city_label", :class => 'control-label'}
       = t("labels.city")
       %small
         = image_tag "lock.png", :class => "lock", :alt => t("captions.private"), :title => t("captions.private")
     = f.text_field "city", :placeholder => t("defaults.city"), :class => "form-control"
   %fieldset.form-group
-    %label{:for => "user_state", :id => "user_state_label"}
+    %label{:for => "user_state", :id => "user_state_label", :class => 'control-label'}
       = t("labels.state")
       %small
         = image_tag "lock.png", :class => "lock", :alt => t("captions.private"), :title => t("captions.private")
     = f.select "state", us_states, {:include_blank => true}, {:class => "form-control"}
   %fieldset.form-group
-    %label{:for => "user_zip", :id => "user_zip_label"}
+    %label{:for => "user_zip", :id => "user_zip_label", :class => 'control-label'}
       = t("labels.zip")
       %small
         = image_tag "lock.png", :class => "lock", :alt => t("captions.private"), :title => t("captions.private")
     = f.text_field "zip", :placeholder => t("defaults.zip"), :class => "form-control"
   %fieldset.form-group
-    %label{:for => "user_password", :id => "user_password_label"}
+    %label{:for => "user_password", :id => "user_password_label", :class => 'control-label'}
       = t("labels.password_new")
       %small
         = t("captions.optional")
     = f.password_field "password", :class => "form-control"
   %fieldset.form-group
-    %label{:for => "user_current_password", :id => "user_current_password_label"}
+    %label{:for => "user_current_password", :id => "user_current_password_label", :class => 'control-label'}
       = t("labels.password_current")
       %small
         = t("captions.required")

--- a/app/views/things/adopt.html.haml
+++ b/app/views/things/adopt.html.haml
@@ -4,7 +4,7 @@
   = f.hidden_field "id"
   = f.hidden_field "user_id", :value => current_user.id
   %fieldset.form-group
-    = f.label "name", t("labels.name_thing", :thing => t("defaults.thing")), :id => "thing_name_label"
+    = f.label "name", t("labels.name_thing", :thing => t("defaults.thing")), :id => "thing_name_label", :class => "control-label"
     = f.text_field "name", :class => "form-control"
   %fieldset.form-group
     = f.submit t("buttons.adopt"), :class => "btn btn-primary btn-block"


### PR DESCRIPTION
Needed to update the CSS class for errors to be `has-error` and mark all
of the labels associated with inputs with the class `control-label` to
have the newer Bootstrap CSS mark the fields correctly.

Addresses #58