### PR TITLE
Hide phone number fields

### DIFF
--- a/app/views/sidebar/_combo_form.html.haml
+++ b/app/views/sidebar/_combo_form.html.haml
@@ -23,13 +23,13 @@
         %small
           = t("captions.public")
       = f.text_field "organization", :class => "form-control"
-    .form-group
+    .form-group.hidden
       %label.control-label{:for => "user_voice_number", :id => "user_voice_number_label"}
         = t("labels.voice_number")
         %small
           = image_tag "lock.png", :class => "lock", :alt => t("captions.private"), :title => t("captions.private")
       = f.telephone_field "voice_number", :placeholder => t("defaults.voice_number"), :class => "form-control"
-    .form-group
+    .form-group.hidden
       %label.control-label{:for => "user_sms_number", :id => "user_sms_number_label"}
         = t("labels.sms_number")
         %small


### PR DESCRIPTION
Addresses #56 

The fields aren't required, so simplest route is to just hide them.