### PR TITLE
Only allow admins to send reminders

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ group :assets do
 end
 
 group :development do
+  gem 'byebug'
   gem 'mailcatcher'
   gem 'spring'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,6 +43,7 @@ GEM
       parser (~> 2.2)
     bcrypt (3.1.10)
     builder (3.2.2)
+    byebug (8.2.1)
     coffee-rails (4.1.0)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0, < 5.0)
@@ -254,6 +255,7 @@ PLATFORMS
 
 DEPENDENCIES
   arel
+  byebug
   coveralls
   devise
   fastercsv

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,6 +7,13 @@ class ApplicationController < ActionController::Base
 
 protected
 
+  def require_admin
+    return if user_signed_in? && current_user.admin?
+
+    flash[:error] = 'You must be an admin'
+    redirect_to root_path
+  end
+
   def set_flash_from_params
     params.fetch(:flash, []).each do |key, message|
       flash.now[key.to_sym] = message

--- a/app/controllers/reminders_controller.rb
+++ b/app/controllers/reminders_controller.rb
@@ -1,6 +1,8 @@
 class RemindersController < ApplicationController
   respond_to :json
 
+  before_action :require_admin
+
   def create
     @reminder = Reminder.new(reminder_params)
     @reminder.from_user = current_user

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,2 +1,5 @@
 module UsersHelper
+  def admin_signed_in?
+    user_signed_in? && current_user.admin?
+  end
 end

--- a/app/views/users/profile.html.haml
+++ b/app/views/users/profile.html.haml
@@ -4,5 +4,5 @@
   = t("titles.byline", :name => @thing.user.name)
   %br
   = t("titles.ofline", :organization => @thing.user.organization) unless @thing.user.organization.blank?
-- if user_signed_in?
+- if admin_signed_in?
   = render :partial => 'users/reminder'

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -15,3 +15,11 @@ dan:
   sms_number: 1234567890
   encrypted_password: "$2a$10$KF/JMZ494ZLhWLgHZeBTf.cSL4l0Wjij4gIZP7BzkueAC1p4nW0ma"
 
+admin:
+  name: Admin User
+  organization: Code for America
+  email: admin@example.com
+  voice_number: 1234567890
+  sms_number: 1234567890
+  encrypted_password: "$2a$10$KF/JMZ494ZLhWLgHZeBTf.cSL4l0Wjij4gIZP7BzkueAC1p4nW0ma"
+  admin: true


### PR DESCRIPTION
Only show the button if they are an admin and protect the reminder
endpoint.

Also include byebug for runtime inspection while debugging.

Addresses #79 