### PR TITLE
Update social media copy

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -85,7 +85,7 @@ en:
     sign_in: "Sign in to adopt this %{thing}"
     thank_you: "Thank you for adopting this %{thing}!"
     email_text: "The rains of El Nino are coming! So I just adopted one of San Francisco's 25,000+ storm drains and pledged to help keep it clear of leaves and debris this rainy season. You too can lend a hand and help the City avoid flooding at %{root_url}. Adopting a drain only takes about 30 seconds -- and you even get to name your drain!"
-    tweet_text: "Flooded streets aren’t fun. I adopted my own storm drain at %{root_url}. Claim and name yours #ElNino #sfsewer @sfwater"
+    tweet_text: "Flooded streets aren't fun. I adopted my own storm drain at %{root_url}. Claim and name yours #ElNino #sfsewer @sfwater"
     tos: "Terms of Service"
   site:
     description: "You can adopt a drain in San Francisco to help keep them clear of debris. Lend a hand to helping the City avoid flooding during the rainy season."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -84,8 +84,8 @@ en:
     ofline: "of %{organization}"
     sign_in: "Sign in to adopt this %{thing}"
     thank_you: "Thank you for adopting this %{thing}!"
-    email_text: "Flooded streets aren’t fun. I adopted my own storm drain at %{root_url}. Claim and name yours!"
-    tweet_text: "Flooded streets aren’t fun. I adopted my own storm drain at %{root_url}. Claim and name yours #ElNino #sfsewer"
+    email_text: "The rains of El Nino are coming! So I just adopted one of San Francisco's 25,000+ storm drains and pledged to help keep it clear of leaves and debris this rainy season. You too can lend a hand and help the City avoid flooding at %{root_url}. Adopting a drain only takes about 30 seconds -- and you even get to name your drain!"
+    tweet_text: "Flooded streets aren’t fun. I adopted my own storm drain at %{root_url}. Claim and name yours #ElNino #sfsewer @sfwater"
     tos: "Terms of Service"
   site:
     description: "You can adopt a drain in San Francisco to help keep them clear of debris. Lend a hand to helping the City avoid flooding during the rainy season."


### PR DESCRIPTION
Addresses #89 

Facebook sharer doesn't allow default text, so that copy is not included.