### PR TITLE
Added the tzinfo gem for Windows support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,8 @@ gem 'rails_12factor'
 gem 'rails_admin'
 gem 'validates_formatting_of'
 
+gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw]
+
 platforms :ruby_18 do
   gem 'fastercsv'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,6 +42,7 @@ GEM
     astrolabe (1.3.1)
       parser (~> 2.2)
     bcrypt (3.1.10)
+    bcrypt (3.1.10-x64-mingw32)
     builder (3.2.2)
     byebug (8.2.1)
     coffee-rails (4.1.0)
@@ -76,6 +77,7 @@ GEM
     eventmachine (1.0.5)
     execjs (2.6.0)
     fastercsv (1.5.5)
+    ffi (1.9.10-x64-mingw32)
     font-awesome-rails (4.5.0.0)
       railties (>= 3.2, < 5.0)
     geokit (1.10.0)
@@ -117,11 +119,14 @@ GEM
     netrc (0.11.0)
     nokogiri (1.6.7)
       mini_portile2 (~> 2.0.0.rc2)
+    nokogiri (1.6.7-x64-mingw32)
+      mini_portile2 (~> 2.0.0.rc2)
     obscenity (1.0.2)
     orm_adapter (0.5.0)
     parser (2.2.3.0)
       ast (>= 1.1, < 3.0)
     pg (0.18.4)
+    pg (0.18.4-x64-mingw32)
     powerpack (0.1.1)
     puma (2.15.3)
     rack (1.6.4)
@@ -184,6 +189,11 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 3.0)
       netrc (~> 0.7)
+    rest-client (1.8.0-x64-mingw32)
+      ffi (~> 1.9)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 3.0)
+      netrc (~> 0.7)
     rubocop (0.35.1)
       astrolabe (~> 1.3)
       parser (>= 2.2.3.0, < 3.0)
@@ -223,6 +233,7 @@ GEM
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)
     sqlite3 (1.3.11)
+    sqlite3 (1.3.11-x64-mingw32)
     term-ansicolor (1.3.2)
       tins (~> 1.0)
     thin (1.5.1)
@@ -235,12 +246,15 @@ GEM
     tins (1.6.0)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
+    tzinfo-data (1.2016.1)
+      tzinfo (>= 1.0.0)
     uglifier (2.7.2)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.1)
+    unf_ext (0.0.7.1-x64-mingw32)
     validates_formatting_of (0.9.0)
       activemodel
     warden (1.2.4)
@@ -252,6 +266,7 @@ GEM
 
 PLATFORMS
   ruby
+  x64-mingw32
 
 DEPENDENCIES
   arel
@@ -276,9 +291,10 @@ DEPENDENCIES
   skylight
   spring
   sqlite3
+  tzinfo-data
   uglifier
   validates_formatting_of
   webmock
 
 BUNDLED WITH
-   1.10.6
+   1.11.2


### PR DESCRIPTION
A simple addition that makes developing off of Windows possible.

Based off of this article: https://github.com/tzinfo/tzinfo/wiki/Resolving-TZInfo::DataSourceNotFound-Errors