### PR TITLE
Make sure the data dismiss attribute is set on dynamically injected alerts

### DIFF
--- a/app/assets/javascripts/main.js.erb
+++ b/app/assets/javascripts/main.js.erb
@@ -241,7 +241,7 @@ $(function() {
   function showFlash(type, message) {
     $('#content').prepend(
         $('<div></div>').addClass('alert fade in alert-' + type).data('alert', '').append(
-          $('<a></a>').addClass('close').data('dismiss', 'alert').text('×')).append(
+          $('<a></a>').addClass('close').attr('data-dismiss', 'alert').text('×')).append(
           $('<p></p>').text(message)
           ));
   }


### PR DESCRIPTION
Otherwise they don't dismiss correctly. Using `.data()` doesn't set the
attribute, which it appears is required by bootstrap.

Fixes #163