### PR TITLE
Fix Mailer Deprecations

### DIFF
--- a/app/controllers/reminders_controller.rb
+++ b/app/controllers/reminders_controller.rb
@@ -7,7 +7,7 @@ class RemindersController < ApplicationController
     @reminder = Reminder.new(reminder_params)
     @reminder.from_user = current_user
     if @reminder.save
-      ThingMailer.reminder(@reminder.thing).deliver
+      ThingMailer.reminder(@reminder.thing).deliver_later
       @reminder.update_attribute(:sent, true)
       render(json: @reminder)
     else

--- a/app/controllers/things_controller.rb
+++ b/app/controllers/things_controller.rb
@@ -26,9 +26,9 @@ private
   def send_adoption_email(user, thing)
     case user.things.count
     when 1
-      ThingMailer.first_adoption_confirmation(thing).deliver
+      ThingMailer.first_adoption_confirmation(thing).deliver_later
     when 2
-      ThingMailer.second_adoption_confirmation(thing).deliver
+      ThingMailer.second_adoption_confirmation(thing).deliver_later
     end
   end
 


### PR DESCRIPTION
The old `#deliver` method is deprecated.
Using new Rails 5 `#deliver_later` instead.