### PR TITLE
Allow the user to search before signing in

### DIFF
--- a/app/assets/javascripts/main.js.erb
+++ b/app/assets/javascripts/main.js.erb
@@ -362,6 +362,7 @@ $(function() {
       }
     });
   }
+
   $('.sidebar').on('click', '#combo-form input[type="radio"]', function() {
     var radioInput = $(this);
     if('new' === radioInput.val()) {
@@ -827,7 +828,7 @@ $(function() {
     });
     return false;
   });
-  $('.sidebar').on('click','#back_link', function() {
+  $('.sidebar').on('click','.link', function() {
     var link = $(this);
     $(link).addClass('disabled');
     $.ajax({

--- a/app/assets/stylesheets/screen.css
+++ b/app/assets/stylesheets/screen.css
@@ -43,6 +43,24 @@ input#user_existing {
 form select, button.btn, input[type="submit"].btn {
 }
 
+.btn-primary {
+  color: #ffffff;
+  background-color: #8871B3;
+  border-color: #8871B3;
+}
+
+.btn-secondary {
+  color: #fff;
+  background-color: #396B80;
+  border-color: #2e6da4;
+}
+
+.btn-secondary:hover {
+  color: #fff;
+  background-color: #005596;
+}
+
+
 form input.search-query {
   -moz-border-radius: 14px;
   -webkit-border-radius: 14px;

--- a/app/views/main/index.html.haml
+++ b/app/views/main/index.html.haml
@@ -22,7 +22,8 @@
           - elsif @reset_password_token.present?
             = render :partial => 'passwords/edit'
           - else
-            = render :partial => "sidebar/combo_form"
+            %iframe{ :width => "100%", :src => "https://www.youtube.com/embed/Z1Vjrx3IAH0", :frameborder => "0", :allowfullscreen => "allowfullscreen" }
+            = render :partial => "sidebar/search"
         -# Corresponds to guideline div above
         %div.hidden.visible-xs-block
           %a.guidelines{:href => "#guidelines", :"data-toggle" => "modal", :"data-target" => "#guidelines"}

--- a/app/views/passwords/_edit.html.haml
+++ b/app/views/passwords/_edit.html.haml
@@ -10,5 +10,5 @@
   .help-block
   %fieldset.form-actions
     = f.submit t("buttons.update"), :class => "btn btn-primary btn-block"
-    %a{:href => combo_form_path, :id => "back_link", :class => "btn btn-default"}
+    %a{:href => combo_form_path, :class => "link btn btn-default"}
       = t("buttons.back")

--- a/app/views/sidebar/_combo_form.html.haml
+++ b/app/views/sidebar/_combo_form.html.haml
@@ -1,4 +1,3 @@
-%iframe{ :width => "100%", :src => "https://www.youtube.com/embed/Z1Vjrx3IAH0", :frameborder => "0", :allowfullscreen => "allowfullscreen" }
 = form_for :user, :html => {:id => "combo-form", :class => "form-vertical"} do |f|
   %fieldset#common_fields
     .form-group
@@ -70,3 +69,5 @@
       = link_to t("links.remembered_password"), "#", :id => "user_remembered_password_link"
     .form-actions
       = f.submit t("buttons.email_password"), :class => "btn btn-primary btn-block"
+%a{:href => search_path, :class => "link btn btn-default"}
+  = t("buttons.back")

--- a/app/views/sidebar/_search.html.haml
+++ b/app/views/sidebar/_search.html.haml
@@ -1,6 +1,5 @@
 = form_tag "/address", :method => "get", :id => "address_form", :class => "search-form" do
   = hidden_field_tag "limit", params[:limit] || 25
-  = hidden_field_tag "current_user_id", current_user.id
   %fieldset.form-group.hidden
     = label_tag "city_state", t("labels.city_state"), :id => "city_state_label", :class => 'control-label'
     = select_tag "city_state", "<option value=\"#{t("defaults.city_state")}\" selected=\"selected\">#{t("defaults.city_state")}</option>".html_safe, :class => "form-control"
@@ -10,16 +9,13 @@
     .help-block
   %fieldset.form-actions
     = submit_tag t("buttons.find", :thing => t("defaults.thing").pluralize), :class => "btn btn-primary btn-block"
-    .break
-  %div.user-things
-    %h5.my-things= t('labels.my_things', :things => t('defaults.things'))
-    %dl
-      - current_user.things.each do |thing|
-        %dt
-          %a.thing-link{ :data => { :lng => thing.lng, :lat => thing.lat } }=thing.name
-        %dd=thing.street_address
-    .break
-    %a{:href => edit_user_registration_path, :id => "edit_profile_link", :class => "btn btn-default btn-block"}
-      = t("buttons.edit_profile")
-    %a{:href => destroy_user_session_path, :id => "sign_out_link", :class => "btn btn-danger btn-block"}
-      = t("buttons.sign_out")
+.break
+- if signed_in?
+  = render :partial => "sidebar/user_things"
+  %a{:href => edit_user_registration_path, :id => "edit_profile_link", :class => "btn btn-warning btn-block"}
+    = t("buttons.edit_profile")
+  %a{:href => destroy_user_session_path, :id => "sign_out_link", :class => "btn btn-danger btn-block"}
+    = t("buttons.sign_out")
+- else
+  %a{:href => combo_form_path, :class => "link btn btn-secondary"}
+    = t("buttons.sign_up_or_in")

--- a/app/views/sidebar/_search.html.haml
+++ b/app/views/sidebar/_search.html.haml
@@ -4,8 +4,7 @@
     = label_tag "city_state", t("labels.city_state"), :id => "city_state_label", :class => 'control-label'
     = select_tag "city_state", "<option value=\"#{t("defaults.city_state")}\" selected=\"selected\">#{t("defaults.city_state")}</option>".html_safe, :class => "form-control"
   %fieldset.form-group
-    = label_tag "address", t("labels.address"), :id => "address_label", :class => 'control-label'
-    = search_field_tag "address", params[:address], :placeholder => [t("defaults.address_1"), t("defaults.neighborhood")].join(", "), :class => "search-query form-control"
+    = search_field_tag "address", params[:address], :placeholder => t("labels.address"), :class => "search-query form-control"
     .help-block
   %fieldset.form-actions
     = submit_tag t("buttons.find", :thing => t("defaults.thing").pluralize), :class => "btn btn-primary btn-block"

--- a/app/views/sidebar/_user_things.html.haml
+++ b/app/views/sidebar/_user_things.html.haml
@@ -1,0 +1,8 @@
+%div.user-things
+  %h5.my-things= t('labels.my_things', :things => t('defaults.things'))
+  %dl
+    - current_user.things.each do |thing|
+      %dt
+        %a.thing-link{ :data => { :lng => thing.lng, :lat => thing.lat } }=thing.name
+      %dd=thing.street_address
+  .break

--- a/app/views/sidebar/edit_profile.html.haml
+++ b/app/views/sidebar/edit_profile.html.haml
@@ -80,7 +80,7 @@
     = f.password_field "current_password", :class => "form-control"
   %fieldset.form-actions
     = f.submit t("buttons.update"), :class => "btn btn-primary btn-block"
-    %a{:href => search_path, :id => "back_link", :class => "btn btn-default"}
+    %a{:href => search_path, :class => "link btn btn-default"}
       = t("buttons.back")
 :javascript
   $(function() {

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -14,6 +14,7 @@ en:
     sign_in: "Sign in"
     sign_out: "Sign out"
     sign_up: "Sign up"
+    sign_up_or_in: "Register / Sign in"
     update: "Update"
   captions:
     optional: "(optional)"

--- a/test/controllers/main_controller_test.rb
+++ b/test/controllers/main_controller_test.rb
@@ -27,7 +27,6 @@ class MainControllerTest < ActionController::TestCase
     assert_select 'select#city_state' do
       assert_select 'option', 'San Francisco, California'
     end
-    assert_select 'label#address_label', 'Address, Neighborhood'
     assert_select 'input#address', true
     assert_select 'input[name="commit"]' do
       assert_select '[type=?]', 'submit'


### PR DESCRIPTION
This will help users discover adoptable drains in their area before
signing up.

This moves user registration / log-in from displaying immediately to
requiring the user to click a button to avoid making the sidebar so
busy.

Addresses #103
