### PR TITLE
Make program background button behave more like a normal button

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -156,6 +156,11 @@ h5.my-things {
   top: 210px;
 }
 
+.btn {
+  white-space: normal !important; /* override bootstrap to wrap button text */
+  word-wrap: break-word;
+}
+
 .btn-primary {
   color: #fff;
   background-color: #396B80;
@@ -220,10 +225,6 @@ h5.my-things {
 
 a.guidelines {
   text-decoration: none;
-}
-
-.sidebar p#tagline:hover {
-  background-color: #9682bc;
 }
 
 .user-things dd {

--- a/app/views/main/index.html.haml
+++ b/app/views/main/index.html.haml
@@ -18,7 +18,7 @@
               Last updated
               = local_date(Time.now, '%B %e, %Y')
           %a.guidelines{:href => "#guidelines", :"data-toggle" => "modal", :"data-target" => "#guidelines"}
-            %p.alert-message.block-message#tagline
+            %button.btn.btn-block.btn-primary#tagline
               = t("defaults.tagline")
         #content
           = render :partial => "layouts/flash", :locals => {:flash => flash}
@@ -32,7 +32,7 @@
         -# Corresponds to guideline div above
         %div.hidden.visible-xs-block
           %a.guidelines{:href => "#guidelines", :"data-toggle" => "modal", :"data-target" => "#guidelines"}
-            %p.alert-message.block-message#tagline
+            %button.btn.btn-block.btn-primary#tagline
               = t("defaults.tagline")
         %a{:href => "#background", :"data-toggle" => "modal", :"data-target" => "#background", :class => "btn btn-secondary"}
           = t("links.learn_more_background")

--- a/app/views/main/unauthenticated.html.haml
+++ b/app/views/main/unauthenticated.html.haml
@@ -3,7 +3,7 @@
     .table-cell.sidebar
       %h1
         = image_tag "logos/adopt-a-drain.png", :alt => t("titles.main", :thing => t("defaults.thing").titleize), :title => t("titles.main", :thing => t("defaults.thing").titleize)
-      %p.alert-message.block-message#tagline
+      %button.btn.btn-block.btn-primary#tagline
         = t("defaults.tagline")
       #content
         = render :partial => "sidebar/combo_form"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -37,7 +37,7 @@ en:
     thing: "drain"
     things: "drains"
     this_thing: "This %{thing}"
-    tagline: "What does it mean to adopt a drain? Click here to find out."
+    tagline: "What does it mean to adopt a drain?"
     tos: "By signing up, you agree to the %{tos}."
     voice_number: "415-555-1212"
     zip: "94015-2013"

--- a/test/controllers/main_controller_test.rb
+++ b/test/controllers/main_controller_test.rb
@@ -12,7 +12,7 @@ class MainControllerTest < ActionController::TestCase
     get :index
     assert_response :success
     assert_select 'title', 'Adopt-a-Drain San Francisco'
-    assert_select 'p#tagline', 'What does it mean to adopt a drain? Click here to find out.'
+    assert_select 'button#tagline', 'What does it mean to adopt a drain?'
   end
 
   test 'should show search form when signed in' do


### PR DESCRIPTION
Change from alert message to traditional button to get highlight and
rounded corner behavior. Also remove "Click here..." text.

Added word-wrap since the default bootstrap behavior is to not wrap text
for buttons, but we need this for buttons like this with longer text.

Fixes #252