### PR TITLE
Move user adoption name to separate field

### DIFF
--- a/app/assets/javascripts/main.js.erb
+++ b/app/assets/javascripts/main.js.erb
@@ -581,7 +581,7 @@ $(function() {
         'authenticity_token': $('#adoption_form input[name="authenticity_token"]').val(),
         'thing': {
           'user_id': $('#thing_user_id').val(),
-          'name': $('#thing_name').val()
+          'adopted_name': $('#thing_adopted_name').val()
         }
       },
       error: function(jqXHR) {
@@ -621,7 +621,7 @@ $(function() {
           'authenticity_token': $('#abandon_form input[name="authenticity_token"]').val(),
           'thing': {
             'user_id': $('#thing_user_id').val(),
-            'name': $('#thing_name').val()
+            'adopted_name': $('#thing_adopted_name').val()
           }
         },
         error: function(jqXHR) {

--- a/app/controllers/things_controller.rb
+++ b/app/controllers/things_controller.rb
@@ -33,6 +33,6 @@ private
   end
 
   def thing_params
-    params.require(:thing).permit(:name, :user_id)
+    params.require(:thing).permit(:adopted_name, :user_id)
   end
 end

--- a/app/models/thing.rb
+++ b/app/models/thing.rb
@@ -31,6 +31,10 @@ class Thing < ActiveRecord::Base
     find_by_sql([query, lat.to_f, lng.to_f, lat.to_f, limit.to_i])
   end
 
+  def display_name
+    (adopted? ? adopted_name : name) || ''
+  end
+
   def reverse_geocode
     @reverse_geocode ||= Geokit::Geocoders::MultiGeocoder.reverse_geocode([lat, lng])
   end
@@ -47,5 +51,9 @@ class Thing < ActiveRecord::Base
     return 'http://sfwater.org/index.aspx?page=399' if system_use_code == 'MS4'
 
     nil
+  end
+
+  def as_json(options = {})
+    super({methods: [:display_name]}.merge(options))
   end
 end

--- a/app/views/sidebar/_user_things.html.haml
+++ b/app/views/sidebar/_user_things.html.haml
@@ -3,6 +3,6 @@
   %dl
     - current_user.things.each do |thing|
       %dt
-        %a.thing-link{ :data => { :lng => thing.lng, :lat => thing.lat } }=thing.name
+        %a.thing-link{ :data => { :lng => thing.lng, :lat => thing.lat } }=thing.display_name
       %dd=thing.street_address
   .break

--- a/app/views/things/_abandon.html.haml
+++ b/app/views/things/_abandon.html.haml
@@ -1,6 +1,6 @@
 = form_for :thing, :url => things_path, :method => :put, :html => {:id => "abandon_form"} do |f|
   = f.hidden_field "id"
   = f.hidden_field "user_id", :value => ""
-  = f.hidden_field "name", :value => ""
+  = f.hidden_field "adopted_name", :value => ""
   %fieldset.form-group
     = f.submit t("buttons.abandon", :thing => t("defaults.thing")), :class => "btn btn-danger btn-block"

--- a/app/views/things/adopt.html.haml
+++ b/app/views/things/adopt.html.haml
@@ -5,7 +5,7 @@
   = f.hidden_field "user_id", :value => current_user.id
   %fieldset.form-group
     = f.label "name", t("labels.name_thing", :thing => t("defaults.thing")), :id => "thing_name_label", :class => "control-label"
-    = f.text_field "name", :class => "form-control"
+    = f.text_field "adopted_name", :value => @thing.name, :class => "form-control"
   %fieldset.form-group
     = f.submit t("buttons.adopt"), :class => "btn btn-primary btn-block"
 

--- a/app/views/users/profile.html.haml
+++ b/app/views/users/profile.html.haml
@@ -1,5 +1,5 @@
 %h4
-  = t("titles.adopted", :thing_name => @thing.name != "" ? @thing.name.titleize : t("defaults.this_thing", :thing => t("defaults.thing")))
+  = t("titles.adopted", :thing_name => @thing.display_name != "" ? @thing.display_name.titleize : t("defaults.this_thing", :thing => t("defaults.thing")))
 %div
   = t("titles.byline", :name => @thing.user.name)
   = t("titles.ofline", :organization => @thing.user.organization) unless @thing.user.organization.blank?

--- a/db/migrate/20170926173203_add_adopted_name_to_things.rb
+++ b/db/migrate/20170926173203_add_adopted_name_to_things.rb
@@ -1,0 +1,13 @@
+class AddAdoptedNameToThings < ActiveRecord::Migration
+  def up
+    add_column :things, :adopted_name, :string
+
+    execute <<-SQL
+      UPDATE things SET adopted_name = name WHERE user_id IS NOT NULL;
+    SQL
+  end
+
+  def down
+    remove_column :things, :adopted_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161205030306) do
+ActiveRecord::Schema.define(version: 20170926173203) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -53,6 +53,7 @@ ActiveRecord::Schema.define(version: 20161205030306) do
     t.integer  "user_id"
     t.string   "system_use_code"
     t.datetime "deleted_at"
+    t.string   "adopted_name"
   end
 
   add_index "things", ["city_id"], name: "index_things_on_city_id", unique: true, using: :btree

--- a/lib/thing_importer.rb
+++ b/lib/thing_importer.rb
@@ -103,10 +103,7 @@ class ThingImporter
         ON CONFLICT(city_id) DO UPDATE SET
           lat = EXCLUDED.lat,
           lng = EXCLUDED.lng,
-          name = CASE
-                   WHEN things.user_id IS NOT NULL THEN things.name
-                   ELSE EXCLUDED.name
-                 END,
+          name = EXCLUDED.name,
           deleted_at = NULL
       SQL
 

--- a/test/lib/thing_importer_test.rb
+++ b/test/lib/thing_importer_test.rb
@@ -62,8 +62,8 @@ class ThingImporterTest < ActiveSupport::TestCase
     assert_equal thing11.lat, BigDecimal.new(37.75, 16)
     assert_equal thing11.lng, BigDecimal.new(-122.40, 16)
 
-    # Asserts properties on thing_10 have been updated, but not the name
-    assert_equal 'Erik drain', thing10.name
+    # Asserts properties on thing_10 have been updated
+    assert_equal 'Catch Basin Drain', thing10.name
     assert_equal BigDecimal.new(36.75, 16), thing10.lat
     assert_equal BigDecimal.new(-121.40, 16), thing10.lng
   end

--- a/test/models/thing_test.rb
+++ b/test/models/thing_test.rb
@@ -23,4 +23,13 @@ class ThingTest < ActiveSupport::TestCase
     t.save!
     assert_equal 1, Thing.adopted.count
   end
+
+  test 'display_name' do
+    t = things(:thing_1)
+    t.name = 'foobar'
+    assert_equal 'foobar', t.display_name
+    t.user = users(:erik)
+    t.adopted_name = 'baz'
+    assert_equal 'baz', t.display_name
+  end
 end


### PR DESCRIPTION
Rather than overwriting the `name` field which is the canonical name of
the thing, store the adopted name separately. This simplifies the import
logic and also allows the displayed drain name to revert back to the
canonical name when a drain is abandoned.