### PR TITLE
Switch from Haversine formula to earth_distance Postgres extension

### DIFF
--- a/app/models/thing.rb
+++ b/app/models/thing.rb
@@ -22,13 +22,13 @@ class Thing < ActiveRecord::Base
 
   def self.find_closest(lat, lng, limit = 10)
     query = <<-SQL
-      SELECT *, (3959 * ACOS(COS(RADIANS(?)) * COS(RADIANS(lat)) * COS(RADIANS(lng) - RADIANS(?)) + SIN(RADIANS(?)) * SIN(RADIANS(lat)))) AS distance
+      SELECT *, earth_distance(ll_to_earth(lat, lng), ll_to_earth(?, ?)) as distance
       FROM things
       WHERE deleted_at is NULL
       ORDER BY distance
       LIMIT ?
       SQL
-    find_by_sql([query, lat.to_f, lng.to_f, lat.to_f, limit.to_i])
+    find_by_sql([query, lat.to_f, lng.to_f, limit.to_i])
   end
 
   def display_name

--- a/db/migrate/20180123031630_enable_earth_distance_extension.rb
+++ b/db/migrate/20180123031630_enable_earth_distance_extension.rb
@@ -1,0 +1,6 @@
+class EnableEarthDistanceExtension < ActiveRecord::Migration
+  def change
+    enable_extension 'cube'
+    enable_extension 'earthdistance'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,10 +11,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170926173203) do
+ActiveRecord::Schema.define(version: 20180123031630) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+  enable_extension "cube"
+  enable_extension "earthdistance"
 
   create_table "rails_admin_histories", force: :cascade do |t|
     t.string   "message"

--- a/lib/adoption_mover.rb
+++ b/lib/adoption_mover.rb
@@ -27,18 +27,11 @@ class AdoptionMover
             deleted_adopted_things
           LEFT JOIN LATERAL (
               SELECT *,
-              -- Haversine formula
-              -- https://developers.google.com/maps/solutions/store-locator/clothing-store-locator#finding-locations-with-mysql
-                (
-                  3959
-                  * ACOS(
-                    COS(RADIANS(deleted_adopted_things.lat))
-                    * COS(RADIANS(unadopted_things.lat))
-                    * COS(RADIANS(unadopted_things.lng) - RADIANS(deleted_adopted_things.lng))
-                    + SIN(RADIANS(deleted_adopted_things.lat))
-                    * SIN(RADIANS(unadopted_things.lat))
-                  )
-                ) * 5280 AS distance_in_feet
+                  -- earth_distance returns meters
+                  earth_distance(
+                    ll_to_earth(deleted_adopted_things.lat, deleted_adopted_things.lng),
+                    ll_to_earth(unadopted_things.lat, unadopted_things.lng)
+                  ) * 3.28 as distance_in_feet
               FROM things AS unadopted_things
               WHERE deleted_at IS NULL AND user_id IS NULL
               ORDER BY distance_in_feet


### PR DESCRIPTION
More readible and solves the issues we had where the query lat/lng
resulting in a value outside of [1,-1] within ACOS() leading to an
error, "input is out of range". This appears to occur when the lat/lng
in the query exactly matches a thing's location. E.g.

```
SELECT
  ACOS(
    COS(RADIANS(37.7876114900295))
    * COS(RADIANS(37.78761149002950))
    * COS(RADIANS(-122.39915856367400) - RADIANS(-122.399158563674))
    + SIN(RADIANS(37.7876114900295))
    * SIN(RADIANS(37.78761149002950))
  )
;
```

Results in `ERROR:  input is out of range`.

I _think_ this is because of floating point imprecision because if we
remove the ACOS:

```
SELECT
  COS(RADIANS(37.7876114900295))
  * COS(RADIANS(37.78761149002950))
  * COS(RADIANS(-122.39915856367400) - RADIANS(-122.399158563674))
  + SIN(RADIANS(37.7876114900295))
  * SIN(RADIANS(37.78761149002950))
;
```

We get `1` which should give an `ACOS(1)` == `0`.