### PR TITLE
Hide user last name from adopted drain info box

### DIFF
--- a/app/views/sidebar/edit_profile.html.haml
+++ b/app/views/sidebar/edit_profile.html.haml
@@ -16,7 +16,7 @@
     %label{:for => "user_last_name", :id => "user_last_name_label", :class => 'control-label'}
       = t("labels.last_name")
       %small
-        = t("captions.public")
+        = image_tag "lock.png", :class => "lock", :alt => t("captions.private"), :title => t("captions.private")
     = f.text_field "last_name", :class => "form-control"
   %fieldset.form-group
     %label{:for => "user_organization", :id => "user_organization_label", :class => 'control-label'}

--- a/app/views/users/profile.html.haml
+++ b/app/views/users/profile.html.haml
@@ -1,5 +1,5 @@
 %h4
   = t("titles.adopted", :thing_name => @thing.display_name != "" ? @thing.display_name.titleize : t("defaults.this_thing", :thing => t("defaults.thing")))
 %div
-  = t("titles.byline", :name => @thing.user.name)
+  = t("titles.byline", :name => @thing.user.first_name)
   = t("titles.ofline", :organization => @thing.user.organization) unless @thing.user.organization.blank?

--- a/test/controllers/info_window_controller_test.rb
+++ b/test/controllers/info_window_controller_test.rb
@@ -40,7 +40,7 @@ class InfoWindowControllerTest < ActionController::TestCase
     assert_response :success
     assert_template 'users/profile'
     assert_select 'h4', /This drain has been adopted/
-    assert_select 'div', /by #{@user.name}\s+of #{@user.organization}/
+    assert_select 'div', /by #{@user.first_name}\s+of #{@user.organization}/
   end
 
   test 'should show adoption form if drain is not adopted' do


### PR DESCRIPTION
To match the labeling on the user registration form as this is the
labeling people are most likely to have seen. Update the user profile
edit form to match this as labeling.