### PR TITLE
Rubocop Rails Fix

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,18 +18,7 @@ Layout/SpaceInsideHashLiteralBraces:
 Layout/AccessModifierIndentation:
   EnforcedStyle: outdent
 
-Metrics/AbcSize:
-  Exclude:
-    - 'app/controllers/passwords_controller.rb'
-    - 'app/controllers/sessions_controller.rb'
-    - 'app/controllers/users_controller.rb'
-    - 'lib/thing_importer.rb'
-    - 'lib/adoption_mover.rb'
-
 Metrics/BlockLength:
-  Exclude:
-    - 'config/initializers/*'
-    - 'lib/adoption_mover.rb' # removing heredocs would decrease readibility
   ExcludedMethods: ['test']
 
 Metrics/BlockNesting:
@@ -44,8 +33,6 @@ Metrics/MethodLength:
   Max: 10
   Exclude:
     - 'db/migrate/*.rb'
-    - 'lib/thing_importer.rb' # removing heredocs would decrease readibility
-    - 'lib/adoption_mover.rb' # removing heredocs would decrease readibility
 
 Metrics/ParameterLists:
   Max: 4
@@ -72,7 +59,3 @@ Style/TrailingCommaInArrayLiteral:
 
 Style/TrailingCommaInHashLiteral:
   EnforcedStyleForMultiline: 'comma'
-
-Style/WordArray:
-  Exclude:
-    - 'app/helpers/application_helper.rb'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ require:
   - rubocop-rails
 
 AllCops:
-  TargetRailsVersion: 4.0
+  TargetRailsVersion: 5.2
   Exclude:
     - 'bin/*'
     - 'db/schema.rb'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
-Rails:
-  Enabled: true
+require:
+  - rubocop-rails
 
 AllCops:
   TargetRailsVersion: 4.0

--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,7 @@ end
 group :test do
   gem 'coveralls', require: false
   gem 'rails-controller-testing' # TODO: remove and replace usages
-  gem 'rubocop'
+  gem 'rubocop-rails'
   gem 'simplecov', require: false
   gem 'webmock'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -206,7 +206,7 @@ GEM
     responders (2.4.1)
       actionpack (>= 4.2.0, < 6.0)
       railties (>= 4.2.0, < 6.0)
-    rubocop (0.72.0)
+    rubocop (0.73.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.6)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -213,6 +213,9 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
+    rubocop-rails (2.2.1)
+      rack (>= 1.1)
+      rubocop (>= 0.72.0)
     ruby-progressbar (1.10.1)
     safe_yaml (1.0.5)
     sass (3.6.0)
@@ -288,7 +291,7 @@ DEPENDENCIES
   rails-controller-testing
   rails_12factor
   rails_admin (~> 1.4)
-  rubocop
+  rubocop-rails
   sass-rails (>= 4.0.3)
   simplecov
   skylight

--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -19,7 +19,7 @@ class PasswordsController < Devise::PasswordsController
     render('main/index')
   end
 
-  def update
+  def update # rubocop:disable Metrics/AbcSize
     self.resource = resource_class.reset_password_by_token(resource_params)
 
     yield resource if block_given?

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,7 +5,7 @@ class UsersController < Devise::RegistrationsController
     render('sidebar/edit_profile', layout: 'sidebar')
   end
 
-  def update
+  def update # rubocop:disable Metrics/AbcSize
     self.resource = resource_class.to_adapter.get!(send(:"current_#{resource_name}").to_key)
     if update_resource(resource, account_update_params)
       yield resource if block_given?
@@ -18,7 +18,7 @@ class UsersController < Devise::RegistrationsController
     end
   end
 
-  def create
+  def create # rubocop:disable Metrics/AbcSize
     build_resource(sign_up_params)
     if resource.save
       yield resource if block_given?

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 module ApplicationHelper
-  def us_states # rubocop:disable MethodLength
+  # rubocop:disable Metrics/MethodLength
+  # rubocop:disable Style/WordArray
+  def us_states
     [
       ['Massachusetts', 'MA'],
       ['Alabama', 'AL'],
@@ -58,4 +60,6 @@ module ApplicationHelper
       ['Wyoming', 'WY'],
     ]
   end
+  # rubocop:enable Metrics/MethodLength
+  # rubocop:enable Style/WordArray
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,8 +5,8 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable, :recoverable, :rememberable,
          :trackable, :validatable
   before_validation :remove_non_digits_from_phone_numbers
-  has_many :reminders_from, class_name: 'Reminder', foreign_key: 'from_user_id', dependent: :destroy
-  has_many :reminders_to, class_name: 'Reminder', foreign_key: 'to_user_id', dependent: :destroy
+  has_many :reminders_from, class_name: 'Reminder', foreign_key: :from_user_id, inverse_of: :from_user, dependent: :destroy
+  has_many :reminders_to, class_name: 'Reminder', foreign_key: :to_user_id, inverse_of: :to_user, dependent: :destroy
   has_many :things, dependent: :nullify
   validates :first_name, presence: true
   validates :last_name, presence: true, on: :create # requirement was added later, grandfather in users

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RailsAdmin.config do |config|
+RailsAdmin.config do |config| # rubocop:disable Metrics/BlockLength
   # internal models
   # https://github.com/sferik/rails_admin/issues/3014
   config.excluded_models = ['ActiveStorage::Blob', 'ActiveStorage::Attachment']

--- a/db/migrate/00000000000002_add_devise_to_users.rb
+++ b/db/migrate/00000000000002_add_devise_to_users.rb
@@ -2,6 +2,7 @@
 
 class AddDeviseToUsers < ActiveRecord::Migration[4.2]
   def up
+    # rubocop:disable Rails/BulkChangeTable
     change_table(:users) do |t|
       ## Database authenticatable
       # t.string :email,              null: false, default: ""
@@ -35,6 +36,7 @@ class AddDeviseToUsers < ActiveRecord::Migration[4.2]
       # Uncomment below if timestamps were not included in your original model.
       # t.timestamps
     end
+    # rubocop:enable Rails/BulkChangeTable
 
     # add_index :users, :email,                unique: true
     add_index :users, :reset_password_token, unique: true

--- a/db/migrate/20160326200455_user_split_name.rb
+++ b/db/migrate/20160326200455_user_split_name.rb
@@ -2,6 +2,7 @@
 
 class UserSplitName < ActiveRecord::Migration[4.2]
   def up
+    # rubocop:disable Rails/BulkChangeTable
     add_column :users, :first_name, :string
     add_column :users, :last_name, :string
     execute <<-SQL
@@ -9,14 +10,17 @@ class UserSplitName < ActiveRecord::Migration[4.2]
       UPDATE users SET last_name = ltrim(substring(name, length(first_name) + 1), ' ');
     SQL
     remove_column :users, :name
+    # rubocop:enable Rails/BulkChangeTable
   end
 
   def down
+    # rubocop:disable Rails/BulkChangeTable
     add_column :users, :name, :string
     execute <<-SQL
       UPDATE users SET name = concat(first_name, ' ', last_name);
     SQL
     remove_column :users, :first_name
     remove_column :users, :last_name
+    # rubocop:enable Rails/BulkChangeTable
   end
 end

--- a/db/migrate/20180509181541_add_priority_to_thing.rb
+++ b/db/migrate/20180509181541_add_priority_to_thing.rb
@@ -2,7 +2,9 @@
 
 class AddPriorityToThing < ActiveRecord::Migration[5.2]
   def change
+    # rubocop:disable Rails/BulkChangeTable
     add_column :things, :priority, :boolean, default: false, null: false
     change_column :things, :priority, :boolean, null: false
+    # rubocop:enable Rails/BulkChangeTable
   end
 end

--- a/lib/adoption_mover.rb
+++ b/lib/adoption_mover.rb
@@ -8,10 +8,13 @@ class AdoptionMover
     # within `maximum_movement_in_feet` away
     #
     # Returns a hash of {to_id: from_id}
+    #
+    # rubocop:disable Metrics/AbcSize
+    # rubocop:disable Metrics/MethodLength
     def move_close_deleted_adoptions(from, maximum_movement_in_feet)
       moved_adoptions = {}
 
-      Thing.transaction do
+      Thing.transaction do # rubocop:disable Metrics/BlockLength
         records = ActiveRecord::Base.connection.execute <<-SQL.strip_heredoc
           WITH
             deleted_adopted_things AS (
@@ -60,5 +63,7 @@ class AdoptionMover
 
       moved_adoptions
     end
+    # rubocop:enable Metrics/AbcSize
+    # rubocop:enable Metrics/MethodLength
   end
 end

--- a/lib/thing_importer.rb
+++ b/lib/thing_importer.rb
@@ -48,6 +48,9 @@ class ThingImporter
     end
 
     # load all of the items into a temporary table, temp_thing_import
+    #
+    # rubocop:disable Metrics/AbcSize
+    # rubocop:disable Metrics/MethodLength
     def import_temp_things(source_url)
       insert_statement_id = SecureRandom.uuid
 
@@ -80,6 +83,8 @@ class ThingImporter
 
       conn.execute('CREATE INDEX "temp_thing_import_city_id" ON temp_thing_import(city_id)')
     end
+    # rubocop:enable Metrics/AbcSize
+    # rubocop:enable Metrics/MethodLength
 
     # mark drains as deleted that do not exist in the new set
     # return the deleted drains partitioned by whether they were adopted
@@ -94,6 +99,7 @@ class ThingImporter
       deleted_things.partition { |thing| thing['user_id'].present? }
     end
 
+    # rubocop:disable Metrics/MethodLength
     def upsert_things
       # postgresql's RETURNING returns both updated and inserted records so we
       # query for the items to be inserted first
@@ -117,5 +123,6 @@ class ThingImporter
 
       created_things
     end
+    # rubocop:enable Metrics/MethodLength
   end
 end


### PR DESCRIPTION
### Problem

https://github.com/sfbrigade/adopt-a-drain/pull/408 caused a development/testing regression since [updating Rubocop to 0.72.0 removed Rails linting support](https://github.com/rubocop-hq/rubocop/issues/5976).

### Solution

Add the [`rubocop-rails` gem](https://github.com/rubocop-hq/rubocop-rails) to restore missing Rails cops.

### Other Changes
I made the following improvements while I had the Rubocop context:
- Bumped to latest Rubocop version (`0.72.0` → `0.73.0`)
- Set target Rails version to `5.2` (from `4.0`)
- Disable cops at specific violations (instead of disabling for entire file)

---

Also, I just adopted my first drain today! 💜❤️🧡💛💚💙